### PR TITLE
Add args to enable/disable backtracking and fast-forwarding in LLInterpreter

### DIFF
--- a/python/llguidance/_lib.pyi
+++ b/python/llguidance/_lib.pyi
@@ -66,7 +66,6 @@ class LLInterpreter:
         llguidance_json: str,
         enable_backtrack: bool = True,
         enable_ff_tokens: bool = True,
-        enable_conditional_ff_tokens: bool = True,
         log_level: int = 1,
     ) -> "LLInterpreter":
         """
@@ -76,7 +75,6 @@ class LLInterpreter:
             llguidance_json: str - the JSON representation of the AG2 grammar/constraint
             enable_backtrack: bool - whether to enable backtracking in the interpreter
             enable_ff_tokens: bool - whether to enable fast-forwarded tokens in the interpreter
-            enable_conditional_ff_tokens: bool - whether to enable conditional fast-forwarded tokens in the interpreter
             log_level: int - the verbosity level of the interpreter
                 0 is silent, 1 is warnings, 2 is verbose
         """

--- a/python/llguidance/_lib.pyi
+++ b/python/llguidance/_lib.pyi
@@ -64,6 +64,9 @@ class LLInterpreter:
         cls,
         tokenizer: LLTokenizer,
         llguidance_json: str,
+        enable_backtrack: bool = True,
+        enable_ff_tokens: bool = True,
+        enable_conditional_ff_tokens: bool = True,
         log_level: int = 1,
     ) -> "LLInterpreter":
         """
@@ -71,6 +74,9 @@ class LLInterpreter:
         Args:
             tokenizer: LLTokenizer - the tokenizer to use
             llguidance_json: str - the JSON representation of the AG2 grammar/constraint
+            enable_backtrack: bool - whether to enable backtracking in the interpreter
+            enable_ff_tokens: bool - whether to enable fast-forwarded tokens in the interpreter
+            enable_conditional_ff_tokens: bool - whether to enable conditional fast-forwarded tokens in the interpreter
             log_level: int - the verbosity level of the interpreter
                 0 is silent, 1 is warnings, 2 is verbose
         """

--- a/rust/src/py.rs
+++ b/rust/src/py.rs
@@ -35,7 +35,6 @@ impl LLInterpreter {
         llguidance_json: &str,
         enable_backtrack: Option<bool>,
         enable_ff_tokens: Option<bool>,
-        enable_conditional_ff_tokens: Option<bool>,
         log_level: Option<isize>,
     ) -> PyResult<Self> {
         let env = tokenizer.clone();
@@ -44,7 +43,7 @@ impl LLInterpreter {
         let inference_caps = InferenceCapabilities {
             backtrack: enable_backtrack.unwrap_or(true),
             ff_tokens: enable_ff_tokens.unwrap_or(true),
-            conditional_ff_tokens: enable_conditional_ff_tokens.unwrap_or(true),
+            conditional_ff_tokens: enable_ff_tokens.unwrap_or(true),
             fork: false,
         };
         let logger = Logger::new(0, std::cmp::max(0, log_level) as u32);

--- a/rust/src/py.rs
+++ b/rust/src/py.rs
@@ -33,15 +33,18 @@ impl LLInterpreter {
     fn py_new(
         tokenizer: &LLTokenizer,
         llguidance_json: &str,
+        enable_backtrack: Option<bool>,
+        enable_ff_tokens: Option<bool>,
+        enable_conditional_ff_tokens: Option<bool>,
         log_level: Option<isize>,
     ) -> PyResult<Self> {
         let env = tokenizer.clone();
         let arg: TopLevelGrammar = serde_json::from_str(llguidance_json).map_err(val_error)?;
         let log_level = log_level.unwrap_or(1);
         let inference_caps = InferenceCapabilities {
-            backtrack: true,
-            ff_tokens: true,
-            conditional_ff_tokens: true,
+            backtrack: enable_backtrack.unwrap_or(true),
+            ff_tokens: enable_ff_tokens.unwrap_or(true),
+            conditional_ff_tokens: enable_conditional_ff_tokens.unwrap_or(true),
             fork: false,
         };
         let logger = Logger::new(0, std::cmp::max(0, log_level) as u32);


### PR DESCRIPTION
Note: This is helpful to integrate llguidance into inference frameworks that do not support backtracking atm.