### PR TITLE
Add tests for numeric regular expressions; some bug fixes

### DIFF
--- a/parser/Cargo.lock
+++ b/parser/Cargo.lock
@@ -599,6 +599,7 @@ dependencies = [
  "lazy_static",
  "rayon",
  "referencing 0.26.1",
+ "regex",
  "regex-syntax",
  "rustc-hash",
  "serde",
@@ -798,6 +799,18 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "serde_json",
+]
+
+[[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -31,3 +31,6 @@ crate-type = ["staticlib", "rlib", "cdylib"]
 
 [build-dependencies]
 cbindgen = "0.27.0"
+
+[dev-dependencies]
+regex = "1.11.1"


### PR DESCRIPTION
Ports the numeric range tests we're currently doing in python into the crate. Found some bugs and fixed them.