### PR TITLE
Add lark and regex compilers to the python API

### DIFF
--- a/python/llguidance/__init__.py
+++ b/python/llguidance/__init__.py
@@ -1,9 +1,11 @@
-from ._lib import LLTokenizer, LLInterpreter, JsonCompiler
+from ._lib import LLTokenizer, LLInterpreter, JsonCompiler, LarkCompiler, RegexCompiler
 from ._tokenizer import TokenizerWrapper
 
 __all__ = [
     "LLTokenizer",
     "LLInterpreter",
     "JsonCompiler",
+    "LarkCompiler",
+    "RegexCompiler",
     "TokenizerWrapper",
 ]

--- a/python/llguidance/_lib.pyi
+++ b/python/llguidance/_lib.pyi
@@ -159,3 +159,36 @@ class JsonCompiler:
         """
         Compile the JSON representation of the AG2 grammar/constraint.
         """
+
+class LarkCompiler:
+    def __new__(
+        cls,
+    ) -> "LarkCompiler":
+        """
+        Create a new Lark compiler.
+        """
+
+    def compile(
+        self,
+        lark: str,
+    ) -> str:
+        """
+        Compile the JSON representation of the AG2 grammar/constraint.
+        """
+
+class RegexCompiler:
+    def __new__(
+        cls,
+    ) -> "RegexCompiler":
+        """
+        Create a new Regex compiler.
+        """
+
+    def compile(
+        self,
+        regex: str,
+        stop_regex: Optional[str] = None,
+    ) -> str:
+        """
+        Compile the JSON representation of the AG2 grammar/constraint.
+        """


### PR DESCRIPTION
Adds `LarkCompiler` and `RegexCompiler` to the python API. Also changes the `JsonCompiler` slightly such that it returns a `TopLevelGrammar` rather than a `GrammarWithLexer` node, such that the output is "ready to consume" by an `LLInterpreter`.

@lochuynh1412 should make your life easier!