### PR TITLE
Cache `NodeRef`s in `grammar_builder`

### DIFF
--- a/parser/src/grammar_builder.rs
+++ b/parser/src/grammar_builder.rs
@@ -177,7 +177,7 @@ impl GrammarBuilder {
 
     pub fn add_node(&mut self, node: Node) -> NodeRef {
         // Generate a key for the node from its serialized form if it is not the placeholder
-        let key = (node != self.placeholder).then(|| serde_json::to_string(&node).unwrap());
+        let key = (node != self.placeholder).then(|| serde_json::to_string(&node).ok()).flatten();
 
         // Return the node reference if it already exists
         if let Some(ref key) = key {

--- a/sample_parser/Cargo.lock
+++ b/sample_parser/Cargo.lock
@@ -856,7 +856,7 @@ checksum = "643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704"
 
 [[package]]
 name = "llguidance_parser"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "cbindgen",


### PR DESCRIPTION
- For the FHIR schema, all the serialization calls slow things down by about 15%, (from ~140ms to build the whole grammar to ~160ms)
- For the FHIR schema, this decreases the size of the compiled grammar by about 30%
- I have concerns about storing serialized grammars as keys, as this should about double the size of our `GrammarBuilder` struct. But this is pretty inconsequential unless we're talking huge schemas like FHIR (and I suppose 2*.7=1.4 means we're not quite doubling the size overall)

There are likely quite a few optimizations we can still do to reduce the time to build grammars, both in the JSON compiler and in `repeat`.

Linked to issue #58 